### PR TITLE
Fix idiosyncrasies between Netlify and proxy

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,7 +8,7 @@ const dirs = {
     partialsDir: './src/partials'
 };
 const exstatic = Exstatic(dirs);
-const STATIC_FILES = ['favicon.ico', 'googlec1e95eb427bc82c1.html', 'robots.txt', 'sitemap.xml', '_redirects'];
+const STATIC_FILES = ['favicon.ico', 'robots.txt', 'sitemap.xml', '_redirects'];
 
 function copyFiles() {
     // Exstatic doesn't currently have support for 1:1 copying

--- a/src/googlec1e95eb427bc82c1.html
+++ b/src/googlec1e95eb427bc82c1.html
@@ -1,1 +1,0 @@
-google-site-verification: googlec1e95eb427bc82c1.html

--- a/src/robots.hexr.org.txt
+++ b/src/robots.hexr.org.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /error_403.html
+Disallow: /404.html
+
+Sitemap: https://www.hexr.org/sitemap.xml

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,5 +1,2 @@
 User-agent: *
-Disallow: /error_403.html
-Disallow: /404.html
-
-Sitemap: https://www.hexr.org/sitemap.xml
+Disallow: /


### PR DESCRIPTION
- HexR Core hosts `robots.txt` and `google*` files so we don't need them here